### PR TITLE
Move dispatches outside of rest calls

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -15,10 +15,9 @@ html, body {
 
 .block-item-div-or-form{
     margin: 5px;
-    border-radius: 10px;
     padding: 10px; 
     width: 55%;
-    background-color: #FFFFFF;
+    background-color: #F5F5F5;
 }
 
 .block-item-div-or-form:hover{
@@ -33,11 +32,10 @@ html, body {
 }
 
 .block-item-button{
-    background-color: #555555;
     border: none;
     color: white;
     padding: 5px;
-    margin: 2px;
+    margin: 0 2px 0 2px;
     text-align: center;
     text-decoration: none;
     font-size: 16px;
@@ -45,9 +43,17 @@ html, body {
     float: right;
 }
 
+.block-item-button:hover{
+    cursor: pointer;
+    box-shadow: 5px 5px 10px rgba(31, 31, 31, 0.4);
+}
+
 .block-item-description{
-  margin: 5px;
+  margin: 0;
   padding: 20px;
-  background-color: #EEEEEE;
   color: #222222;
+}
+
+.block-item-description:hover{
+    cursor: pointer;
 }

--- a/src/components/playlist/PlaylistContainer.js
+++ b/src/components/playlist/PlaylistContainer.js
@@ -21,10 +21,10 @@ const StyledContainer = styled.div`
   height: 80%;
   width: 100%;
   flex:
-  ${props => props.display === DISPLAY_STACK
-      ? '0'
-      : '1'
-      };
+  ${(props) => props.display === DISPLAY_STACK ?
+      '0' :
+      '1'
+};
   background:
   ${(props) => props.mode === PLAYLIST_MODE_WORK ?
       props.theme.primaryLight :

--- a/src/components/playlist/PlaylistDock.js
+++ b/src/components/playlist/PlaylistDock.js
@@ -114,7 +114,7 @@ class PlaylistDock extends Component {
       // finished list
       focusRemainingNew =
         focusInitial.filter((blockId) =>
-          !focusFinished.includes(blockId) && blockId !== focusCurrent
+          !focusFinished.includes(blockId) && blockId !== focusCurrent,
         );
     }
 
@@ -291,11 +291,11 @@ class PlaylistDock extends Component {
     } = this.props;
 
     const minutes = Math.floor(this.state.modeTimeRemaining / 60)
-      .toString()
-      .padStart(2, '0');
+        .toString()
+        .padStart(2, '0');
     const seconds = (this.state.modeTimeRemaining % 60)
-      .toString()
-      .padStart(2, '0');
+        .toString()
+        .padStart(2, '0');
 
     const styleIcon = {
       color: playlistMode === PLAYLIST_MODE_WORK ?
@@ -320,16 +320,16 @@ class PlaylistDock extends Component {
 
           <StyledContainerButton>
             <RefreshRoundedIcon
-            onClick={this.handleClickRestart}
-            style={styleIcon} />
+              onClick={this.handleClickRestart}
+              style={styleIcon} />
 
             <PauseRoundedIcon
-            onClick={this.handleClickPause}
-            style={styleIcon} />
+              onClick={this.handleClickPause}
+              style={styleIcon} />
 
             <ShuffleRoundedIcon
-            onClick={this.handleClickShuffle}
-            style={styleIcon} />
+              onClick={this.handleClickShuffle}
+              style={styleIcon} />
           </StyledContainerButton>
         </StyledBoxColumn>
 

--- a/src/components/stack/BlockItem.js
+++ b/src/components/stack/BlockItem.js
@@ -152,21 +152,14 @@ class BlockItem extends Component {
 
   handleBlockDelete() {
     const {stackFocused} = this.props;
-    this.props.dataBlockDelete({
-
-    }, this.props.blockId, stackFocused);
+    this.props.dataBlockDelete(this.props.blockId, stackFocused);
   }
 
   handleSwapBlocks(currIndex, swapIndex) {
     const {stacks, stackFocused} = this.props;
 
-    const blocksOrderNew = [];
-    const blocksOrderOld = stacks[stackFocused].order;
-
-    // perform a deep copy
-    for (let index = 0; index < blocksOrderOld.length; index++) {
-      blocksOrderNew.push(blocksOrderOld[index]);
-    }
+    // deep copy
+    const blocksOrderNew = [...stacks[stackFocused].order];
 
     if (swapIndex < 0 || swapIndex >= blocksOrderNew.length) {
       return;
@@ -316,14 +309,13 @@ class BlockItem extends Component {
                 value={this.state.description}
                 onChange={this.handleChangeEditDescription}
                 maxLength="255"
-                required
               />
 
               <input
                 type="number"
                 placeholder="Duration"
-                value={this.state.durationWork}
-                onChange={this.handleChangeEditDurationWork / 60}
+                value={this.state.durationWork / 60}
+                onChange={this.handleChangeEditDurationWork}
                 maxLength="255"
                 min="1"
                 max="60"

--- a/src/components/stack/BlockItem.js
+++ b/src/components/stack/BlockItem.js
@@ -1,13 +1,13 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 
 import {
   FOCUS_NONE, FOCUS_HOVER, FOCUS_INFO, FOCUS_EDIT,
 } from '../../util/constants';
 
 
-import { dataBlockUpdate, dataStackUpdate, dataBlockDelete }
+import {dataBlockUpdate, dataStackUpdate, dataBlockDelete}
   from '../../redux/actions/dataActions';
 
 class BlockItem extends Component {
@@ -50,48 +50,48 @@ class BlockItem extends Component {
 
   handleMouseEnterBlock() {
     document.body.style.cursor = 'grab';
-    this.setState({ focusState: FOCUS_HOVER });
+    this.setState({focusState: FOCUS_HOVER});
   }
 
   handleMouseLeaveBlock() {
-    this.setState({ focusState: FOCUS_NONE });
+    this.setState({focusState: FOCUS_NONE});
     document.body.style.cursor = ''; // default arrow cursor
   }
 
   handleClickEye() {
-    this.setState({ focusState: FOCUS_INFO });
+    this.setState({focusState: FOCUS_INFO});
   }
 
   handleClickCancel(e) {
     e.preventDefault();
-    this.setState({ focusState: FOCUS_INFO });
+    this.setState({focusState: FOCUS_INFO});
   }
 
   handleClickEdit() {
-    const { blocks, blockId } = this.props;
+    const {blocks, blockId} = this.props;
     this.setState(
-      {
-        focusState: FOCUS_EDIT,
-        task: blocks[blockId].task,
-        durationWork: blocks[blockId].durationWork,
-        durationBreak: blocks[blockId].durationBreak,
-        description: blocks[blockId].description,
-      });
+        {
+          focusState: FOCUS_EDIT,
+          task: blocks[blockId].task,
+          durationWork: blocks[blockId].durationWork,
+          durationBreak: blocks[blockId].durationBreak,
+          description: blocks[blockId].description,
+        });
   }
 
   handleCloseInfo() {
-    this.setState({ focusState: FOCUS_NONE });
+    this.setState({focusState: FOCUS_NONE});
   }
 
   handleIncrementBursts() {
-    const { blocks, blockId } = this.props;
+    const {blocks, blockId} = this.props;
     if (this.state.numBursts < 10) {
       this.handleBurstsUpdate(blocks[blockId].numBursts + 1);
     }
   }
 
   handleDecrementBursts() {
-    const { blocks, blockId } = this.props;
+    const {blocks, blockId} = this.props;
     if (this.state.numBursts > 1) {
       this.handleBurstsUpdate(blocks[blockId].numBursts - 1);
     }
@@ -99,31 +99,31 @@ class BlockItem extends Component {
 
   /* Input boxes change handlers */
   handleChangeEditTask(e) {
-    this.setState({ task: e.target.value });
+    this.setState({task: e.target.value});
   }
 
   handleChangeEditDescription(e) {
     this.setState(
-      { description: e.target.value },
+        {description: e.target.value},
     );
   }
 
   handleChangeEditDurationWork(e) {
     this.setState(
-      { durationWork: e.target.value * 60 },
+        {durationWork: e.target.value * 60},
     );
   }
 
   handleChangeEditDurationBreak(e) {
     this.setState(
-      { durationBreak: e.target.value * 60 },
+        {durationBreak: e.target.value * 60},
     );
   }
 
   handleBlockUpdate(e) {
     e.preventDefault();
-    this.setState({ focusState: FOCUS_INFO });
-    const { blocks, blockId } = this.props;
+    this.setState({focusState: FOCUS_INFO});
+    const {blocks, blockId} = this.props;
     this.props.dataBlockUpdate({
       ...blocks[blockId],
       task: this.state.task,
@@ -134,16 +134,16 @@ class BlockItem extends Component {
   }
 
   handleBurstsUpdate(newBurstsValue) {
-    const { blocks, blockId } = this.props;
+    const {blocks, blockId} = this.props;
     this.props.dataBlockUpdate({
       ...blocks[blockId],
       numBursts: newBurstsValue,
     }, this.props.blockId);
-    this.setState({ numBursts: newBurstsValue });
+    this.setState({numBursts: newBurstsValue});
   }
 
   handleOrderUpdate(newOrder) {
-    const { stacks, stackFocused } = this.props;
+    const {stacks, stackFocused} = this.props;
     this.props.dataStackUpdate({
       ...stacks[stackFocused],
       order: newOrder,
@@ -151,14 +151,14 @@ class BlockItem extends Component {
   }
 
   handleBlockDelete() {
-    const { stackFocused } = this.props;
+    const {stackFocused} = this.props;
     this.props.dataBlockDelete({
 
     }, this.props.blockId, stackFocused);
   }
 
   handleSwapBlocks(currIndex, swapIndex) {
-    const { stacks, stackFocused } = this.props;
+    const {stacks, stackFocused} = this.props;
 
     const blocksOrderNew = [];
     const blocksOrderOld = stacks[stackFocused].order;
@@ -179,7 +179,7 @@ class BlockItem extends Component {
 
   // Finite state machine
   render() {
-    const { blocks, blockId, stacks, stackFocused } = this.props;
+    const {blocks, blockId, stacks, stackFocused} = this.props;
     const blocksOrder = stacks[stackFocused].order;
     const currIndex = blocksOrder.indexOf(blockId);
     let blockItem;
@@ -211,7 +211,7 @@ class BlockItem extends Component {
                 onMouseEnter={this.handleMouseEnterButton}
                 onMouseLeave={this.handleMouseLeaveButton}
                 className="block-item-button"
-                style={{ float: 'left' }}
+                style={{float: 'left'}}
                 onClick={this.handleBlockDelete}>
                 ❌
               </button>
@@ -266,13 +266,13 @@ class BlockItem extends Component {
         blockItem = (
           <center>
             <div className="block-item-div-or-form" >
-              <span style={{ margin: '5px', fontWeight: 'bold' }}>
+              <span style={{margin: '5px', fontWeight: 'bold'}}>
                 {blocks[blockId].task}
               </span>
-              <span style={{ margin: '5px', float: 'right' }}>
+              <span style={{margin: '5px', float: 'right'}}>
                 <b>{blocks[blockId].durationWork / 60}</b> min burst
               </span>
-              <span style={{ margin: '5px', float: 'right' }}>
+              <span style={{margin: '5px', float: 'right'}}>
                 <b>{blocks[blockId].durationBreak / 60}</b> min break
               </span>
               <div className="block-item-description" >
@@ -280,13 +280,13 @@ class BlockItem extends Component {
               </div>
               <button
                 className="block-item-button"
-                style={{ float: 'none', color: 'black' }}
+                style={{float: 'none', color: 'black'}}
                 onClick={this.handleClickEdit}>
                 Edit
               </button>
               <button
                 className="block-item-button"
-                style={{ float: 'none', color: 'black' }}
+                style={{float: 'none', color: 'black'}}
                 onClick={this.handleCloseInfo}>
                 Close
               </button>
@@ -345,12 +345,12 @@ class BlockItem extends Component {
                   className="block-item-button"
                   type="submit"
                   value="Save"
-                  style={{ color: 'black', float: 'right' }}
+                  style={{color: 'black', float: 'right'}}
                 />
                 <button
                   className="block-item-button"
                   onClick={this.handleClickCancel}
-                  style={{ color: 'black', float: 'right' }}>
+                  style={{color: 'black', float: 'right'}}>
                   Cancel
                 </button>
               </div>

--- a/src/components/stack/BlockItem.js
+++ b/src/components/stack/BlockItem.js
@@ -1,13 +1,13 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 
 import {
   FOCUS_NONE, FOCUS_HOVER, FOCUS_INFO, FOCUS_EDIT,
 } from '../../util/constants';
 
 
-import {dataBlockUpdate, dataStackUpdate, dataBlockDelete}
+import { dataBlockUpdate, dataStackUpdate, dataBlockDelete }
   from '../../redux/actions/dataActions';
 
 class BlockItem extends Component {
@@ -50,48 +50,48 @@ class BlockItem extends Component {
 
   handleMouseEnterBlock() {
     document.body.style.cursor = 'grab';
-    this.setState({focusState: FOCUS_HOVER});
+    this.setState({ focusState: FOCUS_HOVER });
   }
 
   handleMouseLeaveBlock() {
-    this.setState({focusState: FOCUS_NONE});
+    this.setState({ focusState: FOCUS_NONE });
     document.body.style.cursor = ''; // default arrow cursor
   }
 
   handleClickEye() {
-    this.setState({focusState: FOCUS_INFO});
+    this.setState({ focusState: FOCUS_INFO });
   }
 
   handleClickCancel(e) {
     e.preventDefault();
-    this.setState({focusState: FOCUS_INFO});
+    this.setState({ focusState: FOCUS_INFO });
   }
 
   handleClickEdit() {
-    const {blocks, blockId} = this.props;
+    const { blocks, blockId } = this.props;
     this.setState(
-        {
-          focusState: FOCUS_EDIT,
-          task: blocks[blockId].task,
-          durationWork: blocks[blockId].durationWork,
-          durationBreak: blocks[blockId].durationBreak,
-          description: blocks[blockId].description,
-        });
+      {
+        focusState: FOCUS_EDIT,
+        task: blocks[blockId].task,
+        durationWork: blocks[blockId].durationWork,
+        durationBreak: blocks[blockId].durationBreak,
+        description: blocks[blockId].description,
+      });
   }
 
   handleCloseInfo() {
-    this.setState({focusState: FOCUS_NONE});
+    this.setState({ focusState: FOCUS_NONE });
   }
 
   handleIncrementBursts() {
-    const {blocks, blockId} = this.props;
+    const { blocks, blockId } = this.props;
     if (this.state.numBursts < 10) {
       this.handleBurstsUpdate(blocks[blockId].numBursts + 1);
     }
   }
 
   handleDecrementBursts() {
-    const {blocks, blockId} = this.props;
+    const { blocks, blockId } = this.props;
     if (this.state.numBursts > 1) {
       this.handleBurstsUpdate(blocks[blockId].numBursts - 1);
     }
@@ -99,31 +99,31 @@ class BlockItem extends Component {
 
   /* Input boxes change handlers */
   handleChangeEditTask(e) {
-    this.setState({task: e.target.value});
+    this.setState({ task: e.target.value });
   }
 
   handleChangeEditDescription(e) {
     this.setState(
-        {description: e.target.value},
+      { description: e.target.value },
     );
   }
 
   handleChangeEditDurationWork(e) {
     this.setState(
-        {durationWork: e.target.value},
+      { durationWork: e.target.value * 60 },
     );
   }
 
   handleChangeEditDurationBreak(e) {
     this.setState(
-        {durationBreak: e.target.value},
+      { durationBreak: e.target.value * 60 },
     );
   }
 
   handleBlockUpdate(e) {
     e.preventDefault();
-    this.setState({focusState: FOCUS_INFO});
-    const {blocks, blockId} = this.props;
+    this.setState({ focusState: FOCUS_INFO });
+    const { blocks, blockId } = this.props;
     this.props.dataBlockUpdate({
       ...blocks[blockId],
       task: this.state.task,
@@ -134,16 +134,16 @@ class BlockItem extends Component {
   }
 
   handleBurstsUpdate(newBurstsValue) {
-    const {blocks, blockId} = this.props;
+    const { blocks, blockId } = this.props;
     this.props.dataBlockUpdate({
       ...blocks[blockId],
       numBursts: newBurstsValue,
     }, this.props.blockId);
-    this.setState({numBursts: newBurstsValue});
+    this.setState({ numBursts: newBurstsValue });
   }
 
   handleOrderUpdate(newOrder) {
-    const {stacks, stackFocused} = this.props;
+    const { stacks, stackFocused } = this.props;
     this.props.dataStackUpdate({
       ...stacks[stackFocused],
       order: newOrder,
@@ -151,14 +151,14 @@ class BlockItem extends Component {
   }
 
   handleBlockDelete() {
-    const {stackFocused} = this.props;
+    const { stackFocused } = this.props;
     this.props.dataBlockDelete({
 
     }, this.props.blockId, stackFocused);
   }
 
   handleSwapBlocks(currIndex, swapIndex) {
-    const {stacks, stackFocused} = this.props;
+    const { stacks, stackFocused } = this.props;
 
     const blocksOrderNew = [];
     const blocksOrderOld = stacks[stackFocused].order;
@@ -179,7 +179,7 @@ class BlockItem extends Component {
 
   // Finite state machine
   render() {
-    const {blocks, blockId, stacks, stackFocused} = this.props;
+    const { blocks, blockId, stacks, stackFocused } = this.props;
     const blocksOrder = stacks[stackFocused].order;
     const currIndex = blocksOrder.indexOf(blockId);
     let blockItem;
@@ -211,7 +211,7 @@ class BlockItem extends Component {
                 onMouseEnter={this.handleMouseEnterButton}
                 onMouseLeave={this.handleMouseLeaveButton}
                 className="block-item-button"
-                style={{float: 'left'}}
+                style={{ float: 'left' }}
                 onClick={this.handleBlockDelete}>
                 ❌
               </button>
@@ -266,27 +266,27 @@ class BlockItem extends Component {
         blockItem = (
           <center>
             <div className="block-item-div-or-form" >
-              <span style={{margin: '5px', fontWeight: 'bold'}}>
+              <span style={{ margin: '5px', fontWeight: 'bold' }}>
                 {blocks[blockId].task}
               </span>
-              <span style={{margin: '5px', float: 'right'}}>
-                Burst length: [{blocks[blockId].durationWork}] min
+              <span style={{ margin: '5px', float: 'right' }}>
+                <b>{blocks[blockId].durationWork / 60}</b> min burst
               </span>
-              <span style={{margin: '5px', float: 'right'}}>
-                Break length: [{blocks[blockId].durationBreak}] min
+              <span style={{ margin: '5px', float: 'right' }}>
+                <b>{blocks[blockId].durationBreak / 60}</b> min break
               </span>
               <div className="block-item-description" >
                 {blocks[blockId].description}
               </div>
               <button
                 className="block-item-button"
-                style={{float: 'none', color: 'black'}}
+                style={{ float: 'none', color: 'black' }}
                 onClick={this.handleClickEdit}>
                 Edit
               </button>
               <button
                 className="block-item-button"
-                style={{float: 'none', color: 'black'}}
+                style={{ float: 'none', color: 'black' }}
                 onClick={this.handleCloseInfo}>
                 Close
               </button>
@@ -323,17 +323,21 @@ class BlockItem extends Component {
                 type="number"
                 placeholder="Duration"
                 value={this.state.durationWork}
-                onChange={this.handleChangeEditDurationWork}
+                onChange={this.handleChangeEditDurationWork / 60}
                 maxLength="255"
+                min="1"
+                max="60"
                 required
               />
 
               <input
                 type="number"
                 placeholder="Break"
-                value={this.state.durationBreak}
+                value={this.state.durationBreak / 60}
                 onChange={this.handleChangeEditDurationBreak}
                 maxLength="255"
+                min="1"
+                max="60"
                 required
               />
               <div>
@@ -341,12 +345,12 @@ class BlockItem extends Component {
                   className="block-item-button"
                   type="submit"
                   value="Save"
-                  style={{color: 'black', float: 'right'}}
+                  style={{ color: 'black', float: 'right' }}
                 />
                 <button
                   className="block-item-button"
                   onClick={this.handleClickCancel}
-                  style={{color: 'black', float: 'right'}}>
+                  style={{ color: 'black', float: 'right' }}>
                   Cancel
                 </button>
               </div>

--- a/src/components/stack/BlockList.js
+++ b/src/components/stack/BlockList.js
@@ -1,11 +1,11 @@
-import React, {Component} from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {connect} from 'react-redux';
+import { connect } from 'react-redux';
 
 import BlockItem from './BlockItem';
 
-import {sessionBlockFetchData} from '../../redux/actions/sessionActions';
-import {dataBlockCreate} from '../../redux/actions/dataActions';
+import { sessionBlockFetchData } from '../../redux/actions/sessionActions';
+import { dataBlockCreate } from '../../redux/actions/dataActions';
 
 class BlockList extends Component {
   constructor(props) {
@@ -30,19 +30,19 @@ class BlockList extends Component {
   }
 
   handleChangeTask(e) {
-    this.setState({task: e.target.value});
+    this.setState({ task: e.target.value });
   }
 
   handleChangeDescription(e) {
-    this.setState({description: e.target.value});
+    this.setState({ description: e.target.value });
   }
 
   handleChangeDurationWork(e) {
-    this.setState({durationWork: e.target.value});
+    this.setState({ durationWork: e.target.value * 60 });
   }
 
   handleChangeDurationBreak(e) {
-    this.setState({durationBreak: e.target.value});
+    this.setState({ durationBreak: e.target.value * 60 });
   }
 
   handleBlockCreate(e) {
@@ -54,7 +54,7 @@ class BlockList extends Component {
   }
 
   fetchBlocks() {
-    const {stacks, stackFocused, sessionBlockFetchData} = this.props;
+    const { stacks, stackFocused, sessionBlockFetchData } = this.props;
     if (!stacks[stackFocused].loaded) {
       sessionBlockFetchData(stackFocused);
     }
@@ -69,15 +69,15 @@ class BlockList extends Component {
   }
 
   render() {
-    const {stacks, stackFocused} = this.props;
+    const { stacks, stackFocused } = this.props;
 
     if (!stacks[stackFocused].loaded) {
       return (<h3>Loading blocks</h3>);
     }
     const blockItems = stacks[stackFocused].order
-        .map((blockId) =>
-          <BlockItem key={blockId} blockId={blockId} />,
-        );
+      .map((blockId) =>
+        <BlockItem key={blockId} blockId={blockId} />,
+    );
 
     return (
       <center>
@@ -106,19 +106,23 @@ class BlockList extends Component {
             <input
               type="number"
               placeholder="Duration"
-              value={this.state.durationWork}
+              value={this.state.durationWork / 60}
               onChange={this.handleChangeDurationWork}
-              maxLength="255"
+              min="1"
+              max="60"
               required
+              contentEditable='false'
             />
 
             <input
               type="number"
               placeholder="Break"
-              value={this.state.durationBreak}
+              value={this.state.durationBreak / 60}
               onChange={this.handleChangeDurationBreak}
-              maxLength="255"
+              min="1"
+              max="60"
               required
+              contentEditable='false'
             />
             <input type="submit" value="Add block" />
           </form>

--- a/src/components/stack/BlockList.js
+++ b/src/components/stack/BlockList.js
@@ -1,11 +1,11 @@
-import React, { Component } from 'react';
+import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
+import {connect} from 'react-redux';
 
 import BlockItem from './BlockItem';
 
-import { sessionBlockFetchData } from '../../redux/actions/sessionActions';
-import { dataBlockCreate } from '../../redux/actions/dataActions';
+import {sessionBlockFetchData} from '../../redux/actions/sessionActions';
+import {dataBlockCreate} from '../../redux/actions/dataActions';
 
 class BlockList extends Component {
   constructor(props) {
@@ -30,19 +30,19 @@ class BlockList extends Component {
   }
 
   handleChangeTask(e) {
-    this.setState({ task: e.target.value });
+    this.setState({task: e.target.value});
   }
 
   handleChangeDescription(e) {
-    this.setState({ description: e.target.value });
+    this.setState({description: e.target.value});
   }
 
   handleChangeDurationWork(e) {
-    this.setState({ durationWork: e.target.value * 60 });
+    this.setState({durationWork: e.target.value * 60});
   }
 
   handleChangeDurationBreak(e) {
-    this.setState({ durationBreak: e.target.value * 60 });
+    this.setState({durationBreak: e.target.value * 60});
   }
 
   handleBlockCreate(e) {
@@ -54,7 +54,7 @@ class BlockList extends Component {
   }
 
   fetchBlocks() {
-    const { stacks, stackFocused, sessionBlockFetchData } = this.props;
+    const {stacks, stackFocused, sessionBlockFetchData} = this.props;
     if (!stacks[stackFocused].loaded) {
       sessionBlockFetchData(stackFocused);
     }
@@ -69,15 +69,15 @@ class BlockList extends Component {
   }
 
   render() {
-    const { stacks, stackFocused } = this.props;
+    const {stacks, stackFocused} = this.props;
 
     if (!stacks[stackFocused].loaded) {
       return (<h3>Loading blocks</h3>);
     }
     const blockItems = stacks[stackFocused].order
-      .map((blockId) =>
-        <BlockItem key={blockId} blockId={blockId} />,
-    );
+        .map((blockId) =>
+          <BlockItem key={blockId} blockId={blockId} />,
+        );
 
     return (
       <center>

--- a/src/components/stack/BlockList.js
+++ b/src/components/stack/BlockList.js
@@ -80,48 +80,50 @@ class BlockList extends Component {
         );
 
     return (
-      <div>
-        {blockItems}
-        <form style={{margin: 10, border: '1px solid gray', padding: 5}}
-          onSubmit={this.handleBlockCreate}>
+      <center>
+        <div>
+          {blockItems}
+          <form className="block-item-div-or-form"
+            onSubmit={this.handleBlockCreate}>
 
-          <input
-            type="text"
-            placeholder="Task"
-            value={this.state.task}
-            onChange={this.handleChangeTask}
-            maxLength="255"
-            required
-          />
+            <input
+              type="text"
+              placeholder="Task"
+              value={this.state.task}
+              onChange={this.handleChangeTask}
+              maxLength="255"
+              required
+            />
 
-          <input
-            type="text"
-            placeholder="Description"
-            value={this.state.description}
-            onChange={this.handleChangeDescription}
-            maxLength="255"
-          />
+            <input
+              type="text"
+              placeholder="Description"
+              value={this.state.description}
+              onChange={this.handleChangeDescription}
+              maxLength="255"
+            />
 
-          <input
-            type="number"
-            placeholder="Duration"
-            value={this.state.durationWork}
-            onChange={this.handleChangeDurationWork}
-            maxLength="255"
-            required
-          />
+            <input
+              type="number"
+              placeholder="Duration"
+              value={this.state.durationWork}
+              onChange={this.handleChangeDurationWork}
+              maxLength="255"
+              required
+            />
 
-          <input
-            type="number"
-            placeholder="Break"
-            value={this.state.durationBreak}
-            onChange={this.handleChangeDurationBreak}
-            maxLength="255"
-            required
-          />
-          <input type="submit" value="Add block" />
-        </form>
-      </div>
+            <input
+              type="number"
+              placeholder="Break"
+              value={this.state.durationBreak}
+              onChange={this.handleChangeDurationBreak}
+              maxLength="255"
+              required
+            />
+            <input type="submit" value="Add block" />
+          </form>
+        </div>
+      </center>
     );
   }
 }

--- a/src/components/stack/StackContainer.js
+++ b/src/components/stack/StackContainer.js
@@ -5,20 +5,20 @@ import styled from 'styled-components';
 
 import BlockList from './BlockList';
 import StackDock from './StackDock';
-import PlaylistContainer from '../playlist/PlaylistContainer'
+import PlaylistContainer from '../playlist/PlaylistContainer';
 
-import {StyledBoxColumn} from '../common/styles'
+import {StyledBoxColumn} from '../common/styles';
 
-import {DISPLAY_STACK} from '../../util/constants'
+import {DISPLAY_STACK} from '../../util/constants';
 
 const StyledBoxDynamic = styled(StyledBoxColumn)`
   flex:
-  ${props => props.display === DISPLAY_STACK
-      ? '0'
-      : '1'
-      };
+  ${(props) => props.display === DISPLAY_STACK ?
+      '0' :
+      '1'
+};
   transition: all 0.5s ease-in-out;
-`
+`;
 
 const StyledContainer = styled.div`
   display: flex;
@@ -30,56 +30,56 @@ const StyledContainer = styled.div`
 
 const StyledContainerInner = styled(StyledContainer)`
   height:
-  ${props => props.display === DISPLAY_STACK
-      ? '100%'
-      : '80%'
-      };
-`
+  ${(props) => props.display === DISPLAY_STACK ?
+      '100%' :
+      '80%'
+};
+`;
 
 const StyledContainerStack = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   width: 100%;
-  background: ${props => props.theme.primaryLight};
+  background: ${(props) => props.theme.primaryLight};
   transition: all 0.5s ease-in-out;
   flex:
-  ${props => props.display === DISPLAY_STACK
-      ? '1'
-      : '0'
-      };
+  ${(props) => props.display === DISPLAY_STACK ?
+      '1' :
+      '0'
+};
   height:
-  ${props => props.display === DISPLAY_STACK
-      ? '100%'
-      : '0'
-      };
+  ${(props) => props.display === DISPLAY_STACK ?
+      '100%' :
+      '0'
+};
   visibility:
-  ${props => props.display === DISPLAY_STACK
-      ? 'visible'
-      : 'hidden'
-      };
+  ${(props) => props.display === DISPLAY_STACK ?
+      'visible' :
+      'hidden'
+};
 `;
 
 const StyledContainerText = styled.div`
   display: flex;
   flex:
-  ${props => props.display === DISPLAY_STACK
-      ? '0 1 auto'
-      : '1'
-      };
+  ${(props) => props.display === DISPLAY_STACK ?
+      '0 1 auto' :
+      '1'
+};
   height:
-  ${props => props.display === DISPLAY_STACK
-      ? '8rem'
-      : 'auto'
-      };
-`
+  ${(props) => props.display === DISPLAY_STACK ?
+      '8rem' :
+      'auto'
+};
+`;
 
 const StyledTextName = styled.div`
   font-size: 1.75rem;
   font-weight: 500;
   margin: auto 0 0.5rem 7rem;
-  color: ${props => props.theme.primaryLight};
-`
+  color: ${(props) => props.theme.primaryLight};
+`;
 
 class StackContainer extends Component {
   render() {
@@ -91,9 +91,9 @@ class StackContainer extends Component {
       loadingBlocks,
     } = this.props;
 
-    const componentStack = loadingBlocks || loadingStacks
-      ? null
-      : (
+    const componentStack = loadingBlocks || loadingStacks ?
+      null :
+      (
         <Fragment>
           <BlockList />
           <StackDock />
@@ -104,7 +104,7 @@ class StackContainer extends Component {
     return (
       <StyledContainer>
         <StyledContainerText display={display}>
-           {!loadingStacks && <StyledTextName>{stacks[stackFocused].name}</StyledTextName>}
+          {!loadingStacks && <StyledTextName>{stacks[stackFocused].name}</StyledTextName>}
         </StyledContainerText>
         <StyledContainerInner display={display}>
 

--- a/src/redux/actions/dataActions.js
+++ b/src/redux/actions/dataActions.js
@@ -104,6 +104,10 @@ export const dataBlockUpdate = (blockData, blockId) => (dispatch) => {
   axios.patch(`/blocks/${blockId}`, blockData)
       .then((response) => {
         console.log(`[INFO] Updated: ${blockId}`);
+        dispatch({
+          type: DATA_SET_BLOCK,
+          payload: response.data,
+        });
       })
       .catch((error) => {
         console.log(error);
@@ -115,13 +119,13 @@ export const dataBlockUpdate = (blockData, blockId) => (dispatch) => {
 };
 
 // delete
-export const dataBlockDelete = (blockData, blockId, stackId) =>
+export const dataBlockDelete = (blockId, stackId) =>
   (dispatch) => {
     dispatch({
       type: DATA_DELETE_BLOCK,
       payload: {blockId, stackId},
     });
-    axios.delete(`/blocks/${blockId}`, blockData)
+    axios.delete(`/blocks/${blockId}`)
         .catch((error) => {
           console.log(error);
           dispatch({

--- a/src/redux/actions/dataActions.js
+++ b/src/redux/actions/dataActions.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import {
   DATA_SET_STACK,
   DATA_SET_BLOCK,
+  DATA_DELETE_BLOCK,
   SESSION_ERRORS_SET,
   STACK_SET_STACK_FOCUSED,
 } from '../types';
@@ -38,8 +39,23 @@ export const dataStackCreate = (stackData) => (dispatch) => {
 };
 
 // update
-export const dataStackUpdate = () => (dispatch) => {
-  // TODO
+export const dataStackUpdate = (stackData, stackId) => (dispatch) => {
+  dispatch({
+    type: DATA_SET_STACK,
+    payload: stackData,
+  });
+  console.log(stackData);
+  axios.patch(`stacks/${stackId}`, stackData)
+      .then((response) => {
+        console.log(`[INFO] stack ${stackId} updated`);
+      })
+      .catch((error) => {
+        console.log(error);
+        dispatch({
+          type: SESSION_ERRORS_SET,
+          payload: error.response.data,
+        });
+      });
 };
 
 // delete
@@ -51,11 +67,9 @@ export const dataStackDelete = () => (dispatch) => {
 export const dataBlockCreate = (blockData) => (dispatch) => {
   axios.post(`/blocks`, blockData)
       .then((res) => {
-        console.log('[INFO] Stack created', res.data);
-
+        console.log('[INFO] Block created', res.data);
         // the stack had already been loaded, so set this for consistency
         res.data.stack.loaded = true;
-
         dispatch({
           type: DATA_SET_BLOCK,
           payload: res.data.block,
@@ -77,13 +91,19 @@ export const dataBlockCreate = (blockData) => (dispatch) => {
 
 // update
 export const dataBlockUpdate = (blockData, blockId) => (dispatch) => {
+  console.log(blockData);
+
+  dispatch({
+    type: DATA_SET_BLOCK,
+    payload: {
+      ...blockData,
+      id: blockId,
+    },
+  });
+
   axios.patch(`/blocks/${blockId}`, blockData)
       .then((response) => {
         console.log(`[INFO] Updated: ${blockId}`);
-        dispatch({
-          type: DATA_SET_BLOCK,
-          payload: response.data,
-        });
       })
       .catch((error) => {
         console.log(error);
@@ -95,6 +115,18 @@ export const dataBlockUpdate = (blockData, blockId) => (dispatch) => {
 };
 
 // delete
-export const dataBlockDelete = () => (dispatch) => {
-  // TODO
-};
+export const dataBlockDelete = (blockData, blockId, stackId) =>
+  (dispatch) => {
+    dispatch({
+      type: DATA_DELETE_BLOCK,
+      payload: {blockId, stackId},
+    });
+    axios.delete(`/blocks/${blockId}`, blockData)
+        .catch((error) => {
+          console.log(error);
+          dispatch({
+            type: SESSION_ERRORS_SET,
+            payload: error.response.data,
+          });
+        });
+  };

--- a/src/redux/reducers/dataReducer.js
+++ b/src/redux/reducers/dataReducer.js
@@ -59,8 +59,7 @@ export default (state = INITIAL_STATE, action) => {
         },
       };
 
-      const stackId = action.payload.stackId;
-      const blockId = action.payload.blockId;
+      const {stackId, blockId} = action.payload;
 
       newState.stacks[stackId] = {
         ...state.stacks[stackId],

--- a/src/redux/reducers/dataReducer.js
+++ b/src/redux/reducers/dataReducer.js
@@ -3,6 +3,7 @@ import {
   DATA_SET_STACK,
   DATA_SET_BLOCKS,
   DATA_SET_BLOCK,
+  DATA_DELETE_BLOCK,
   DATA_CLEAR,
 } from '../types';
 
@@ -45,6 +46,29 @@ export default (state = INITIAL_STATE, action) => {
         },
       };
       newState.blocks[action.payload.id] = action.payload;
+      return newState;
+
+    case DATA_DELETE_BLOCK:
+      newState = {
+        ...state,
+        blocks: {
+          ...state.blocks,
+        },
+        stacks: {
+          ...state.stacks,
+        },
+      };
+
+      const stackId = action.payload.stackId;
+      const blockId = action.payload.blockId;
+
+      newState.stacks[stackId] = {
+        ...state.stacks[stackId],
+        order: state.stacks[stackId].order.filter((id) => id !== blockId),
+      };
+
+      delete newState.blocks[blockId];
+
       return newState;
 
     case DATA_CLEAR:

--- a/src/redux/types.js
+++ b/src/redux/types.js
@@ -14,6 +14,7 @@ export const DATA_SET_STACK = 'DATA_SET_STACK';
 export const DATA_SET_BLOCKS = 'DATA_SET_BLOCKS';
 export const DATA_SET_BLOCK = 'DATA_SET_BLOCK';
 export const DATA_CLEAR = 'DATA_CLEAR';
+export const DATA_DELETE_BLOCK = 'DATA_DELETE_BLOCK';
 
 // displayPlaylist
 export const PLAYLIST_SET_MODE = 'PLAYLIST_SET_MODE';


### PR DESCRIPTION
Notes:
- move the dispatches for all methods except dataBlockCreate
- small bug if incrementing/decrementing numBursts fast still persists
- no delays the experience with block item interactions
- tiny delay when creating block since dispatch wasn't moved out
- focused on dispatches that are going to be used more frequently

Features completed:

- rearranging block items
- incrementing/decrementing numBursts
- deleting block items
- editing and saving block items
- redux actions for dispatching and firebase calls without delay
- added some basic css and style tags (this will be replaced by styled components)
- centered jsx elements in blockItem.js